### PR TITLE
Factor common HGCal custom commands

### DIFF
--- a/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
@@ -354,6 +354,7 @@ def cust_2023SHCalNoExtPix(process):
         process.ecalEndcapRecoSummary.recHitCollection_EE = cms.InputTag("ecalRecHit","EcalRecHitsEK")
 
     return process
+
 def cust_2023HGCal_common(process):
     process=customisePostLS1(process)
     process=customiseBE5DPixel10D(process)
@@ -409,6 +410,7 @@ def cust_2023HGCal_common(process):
             if hasattr(process,'ecalDrivenElectronSeeds'):
                 process.ecalDrivenElectronSeeds.endcapSuperClusters = cms.InputTag('particleFlowSuperClusterHGCEE')
                 process.ecalDrivenElectronSeeds.SeedConfiguration.endcapHCALClusters = cms.InputTag('particleFlowClusterHGCHEF')
+                process.ecalDrivenElectronSeeds.SeedConfiguration.hOverEMethodEndcap = cms.int32(3)
                 process.ecalDrivenElectronSeeds.SeedConfiguration.maxHOverEEndcaps = cms.double(0.2) 
                 process.ecalDrivenElectronSeeds.SeedConfiguration.z2MinB = cms.double(-0.15)
                 process.ecalDrivenElectronSeeds.SeedConfiguration.z2MaxB = cms.double(0.15)
@@ -461,95 +463,6 @@ def cust_2023HGCalV6Muon(process):
     """
     process = cust_2023HGCal_common(process)
     process = customise_me0(process)
-    process=customisePostLS1(process)
-    process=customiseBE5DPixel10D(process)
-    process=customise_HcalPhase2(process)
-    process=customise_ev_BE5DPixel10D(process)
-    process=customise_gem2023(process)
-    process=customise_rpc(process)
-    process=customise_me0(process)
-    process=jetCustoms.customise_jets(process)
-    if hasattr(process,'L1simulation_step'):
-    	process.simEcalTriggerPrimitiveDigis.BarrelOnly = cms.bool(True)
-    if hasattr(process,'digitisation_step'):
-    	process.mix.digitizers.ecal.accumulatorType = cms.string('EcalPhaseIIDigiProducer')
-        process.load('SimGeneral.MixingModule.hgcalDigitizer_cfi')
-        process.mix.digitizers.hgceeDigitizer=process.hgceeDigitizer
-        process.mix.digitizers.hgchebackDigitizer=process.hgchebackDigitizer
-        process.mix.digitizers.hgchefrontDigitizer=process.hgchefrontDigitizer
-        # Also need to tell the MixingModule to make the correct collections available from
-        # the pileup, even if not creating CrossingFrames.
-        process.mix.mixObjects.mixCH.input.append( cms.InputTag("g4SimHits",process.hgceeDigitizer.hitCollection.value()) )
-        process.mix.mixObjects.mixCH.input.append( cms.InputTag("g4SimHits",process.hgchebackDigitizer.hitCollection.value()) )
-        process.mix.mixObjects.mixCH.input.append( cms.InputTag("g4SimHits",process.hgchefrontDigitizer.hitCollection.value()) )
-        process.mix.mixObjects.mixCH.subdets.append( process.hgceeDigitizer.hitCollection.value() )
-        process.mix.mixObjects.mixCH.subdets.append( process.hgchebackDigitizer.hitCollection.value() )
-        process.mix.mixObjects.mixCH.subdets.append( process.hgchefrontDigitizer.hitCollection.value() )
-    if hasattr(process,'raw2digi_step'):
-        process.ecalDigis.FEDs = cms.vint32(
-            # EE-:
-            #601, 602, 603, 604, 605,
-            #606, 607, 608, 609,
-            # EB-:
-            610, 611, 612, 613, 614, 615,
-            616, 617, 618, 619, 620, 621,
-            622, 623, 624, 625, 626, 627,
-            # EB+:
-            628, 629, 630, 631, 632, 633,
-            634, 635, 636, 637, 638, 639,
-            640, 641, 642, 643, 644, 645,
-            # EE+:
-            #646, 647, 648, 649, 650,
-            #651, 652, 653, 654
-            )
-        print "RAW2DIGI only for EB FEDs"
-    if hasattr(process,'reconstruction_step'):
-        process.particleFlowCluster += process.particleFlowRecHitHGC
-        process.particleFlowCluster += process.particleFlowClusterHGC
-        if hasattr(process,'particleFlowSuperClusterECAL'):
-            process.particleFlowSuperClusterHGCEE = process.particleFlowSuperClusterECAL.clone()
-            process.particleFlowSuperClusterHGCEE.useHGCEmPreID = cms.bool(True)
-            process.particleFlowSuperClusterHGCEE.PFClusters = cms.InputTag('particleFlowClusterHGCEE')
-            process.particleFlowSuperClusterHGCEE.use_preshower = cms.bool(False)
-            process.particleFlowSuperClusterHGCEE.PFSuperClusterCollectionEndcapWithPreshower = cms.string('')
-            process.particleFlowCluster += process.particleFlowSuperClusterHGCEE
-            if hasattr(process,'ecalDrivenElectronSeeds'):
-                process.ecalDrivenElectronSeeds.endcapSuperClusters = cms.InputTag('particleFlowSuperClusterHGCEE')
-                process.ecalDrivenElectronSeeds.SeedConfiguration.hOverEMethodEndcap = cms.int32(3) 
-                process.ecalDrivenElectronSeeds.SeedConfiguration.maxHOverEEndcaps = cms.double(0.2) 
-                process.ecalDrivenElectronSeeds.SeedConfiguration.z2MinB = cms.double(-0.15)
-                process.ecalDrivenElectronSeeds.SeedConfiguration.z2MaxB = cms.double(0.15)
-                if hasattr(process,'ecalDrivenGsfElectrons'):
-                    process.ecalDrivenGsfElectrons.hOverEMethodEndcap = cms.int32(3)
-                    process.ecalDrivenGsfElectrons.hcalEndcapClusters = cms.InputTag('particleFlowClusterHGCHEF')
-                    if hasattr(process,'gsfElectrons'):
-                        process.gsfElectrons.hOverEMethodEndcap = cms.int32(3)
-                        process.gsfElectrons.hcalEndcapClusters = cms.InputTag('particleFlowClusterHGCHEF')
-        if hasattr(process,'particleFlowBlock'):
-            process.particleFlowBlock.elementImporters.append( cms.PSet( importerName = cms.string('HGCECALClusterImporter'),
-                                                                         source = cms.InputTag('particleFlowClusterHGCEE') ) )
-            process.particleFlowBlock.linkDefinitions.append( cms.PSet( linkerName = cms.string('TrackAndHGCEELinker'),
-                                                                        linkType = cms.string('TRACK:HGC_ECAL'),
-                                                                        useKDTree = cms.bool(True) ) )
-            process.particleFlowBlock.linkDefinitions.append( cms.PSet( linkerName = cms.string('TrackAndHGCHEFLinker'),
-                                                                        linkType = cms.string('TRACK:HGC_HCALF'),
-                                                                        useKDTree = cms.bool(True) ) )
-            process.particleFlowBlock.linkDefinitions.append( cms.PSet( linkerName = cms.string('TrackAndHGCHEBLinker'),
-                                                                        linkType = cms.string('TRACK:HGC_HCALB'),
-                                                                        useKDTree = cms.bool(True) ) )
-            process.particleFlowBlock.linkDefinitions.append( cms.PSet( linkType = cms.string('SC:HGC_ECAL'),
-                                                                        SuperClusterMatchByRef = cms.bool(True),
-                                                                        useKDTree = cms.bool(False),
-                                                                        linkerName = cms.string('SCAndECALLinker') ) )
-            
-    #mod event content
-    process.load('RecoLocalCalo.Configuration.hgcalLocalReco_EventContent_cff')
-    if hasattr(process,'FEVTDEBUGHLTEventContent'):
-        process.FEVTDEBUGHLTEventContent.outputCommands.extend(process.hgcalLocalRecoFEVT.outputCommands)
-        process.FEVTDEBUGHLTEventContent.outputCommands.append('keep *_particleFlowSuperClusterHGCEE_*_*')
-    if hasattr(process,'RECOSIMEventContent'):
-        process.RECOSIMEventContent.outputCommands.extend(process.hgcalLocalRecoFEVT.outputCommands)
-        process.RECOSIMEventContent.outputCommands.append('keep *_particleFlowSuperClusterHGCEE_*_*')
     return process
 
 def cust_2023SHCalTime(process):


### PR DESCRIPTION
Remove the HGCal V6 custom commands, which are all already done by the call to `cust_2023HGCal_common`.  The only line that wasn't in `cust_2023HGCal_common` has been moved there because it should be done for all HGCal scenarios.
