### PR TITLE
Further corrections to ToA and energy from TDC

### DIFF
--- a/RecoLocalCalo/HGCalRecAlgos/interface/HGCalUncalibRecHitRecWeightsAlgo.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/HGCalUncalibRecHitRecWeightsAlgo.h
@@ -47,11 +47,12 @@ template<class C> class HGCalUncalibRecHitRecWeightsAlgo
 	flag       = !sample.threshold();  //raise flag if busy cell
 	amplitude_ = double(sample.data()) * tdcLSB_;
 	jitter_    = double(sample.toa()) * toaLSBToNS_;
-	if(debug) std::cout << "TDC+: set the energy to: " << amplitude_ << ' ' << sample.data() 
-			    << ' ' << tdcLSB_ << std::endl
-			    << "TDC+: set the jitter to: " << jitter_ << ' ' 
-			    << sample.toa() << ' ' << toaLSBToNS_ << ' '
-			    << " flag=" << flag << std::endl;
+	if(debug) 
+	  std::cout << "TDC+: set the energy to: " << amplitude_ << ' ' << sample.data() 
+		    << ' ' << tdcLSB_ << std::endl
+		    << "TDC+: set the jitter to: " << jitter_ << ' ' 
+		    << sample.toa() << ' ' << toaLSBToNS_ << ' '
+		    << " flag=" << flag << std::endl;
       } 
       else {
 	amplitude_ = double(sample.data()) * adcLSB_;

--- a/SimCalorimetry/HGCSimProducers/interface/HGCFEElectronics.h
+++ b/SimCalorimetry/HGCSimProducers/interface/HGCFEElectronics.h
@@ -68,7 +68,7 @@ class HGCFEElectronics
 
   //private members
   uint32_t fwVersion_;
-  std::vector<double> adcPulse_,tdcChargeDrainParameterisation_;
+  std::vector<double> adcPulse_,pulseAvgT_, tdcChargeDrainParameterisation_;
   float adcSaturation_fC_, adcLSB_fC_, tdcLSB_fC_, tdcSaturation_fC_,
     adcThreshold_fC_, tdcOnset_fC_, toaLSB_ns_, tdcResolutionInNs_; 
   

--- a/SimCalorimetry/HGCSimProducers/src/HGCFEElectronics.cc
+++ b/SimCalorimetry/HGCSimProducers/src/HGCFEElectronics.cc
@@ -237,7 +237,6 @@ void HGCFEElectronics<D>::runShaperWithToT(D &dataFrame,std::vector<float> &char
 	  newCharge[it+busyBxs] +=  tdcOnsetLeakage;
 	}
     }
-  debug=false;
   
   //including the leakage from bunches in SARS ADC when not declared busy or in ToT
   for(int it=0; it<(int)(chargeColl.size()); it++)

--- a/SimGeneral/MixingModule/python/hgcalDigitizer_cfi.py
+++ b/SimGeneral/MixingModule/python/hgcalDigitizer_cfi.py
@@ -19,7 +19,8 @@ hgceeDigitizer = cms.PSet( accumulatorType   = cms.string("HGCDigiProducer"),
                                                feCfg   = cms.PSet( # 0 only ADC, 1 ADC with pulse shape, 2 ADC+TDC with pulse shape
                                                                    fwVersion         = cms.uint32(2),
                                                                    # leakage to bunches -2, -1, in-time, +1, +2, +3 (from J. Kaplon)
-                                                                   adcPulse          = cms.vdouble(0.00,0.017,0.817,0.163,0.003,0.000), 
+                                                                   adcPulse          = cms.vdouble(0.00, 0.017,   0.817,   0.163,  0.003,  0.000), 
+                                                                   pulseAvgT         = cms.vdouble(0.00, 23.42298,13.16733,6.41062,5.03946,4.5320), 
                                                                    # n bits for the ADC 
                                                                    adcNbits          = cms.uint32(10),
                                                                    # ADC saturation
@@ -62,7 +63,8 @@ hgchefrontDigitizer = cms.PSet( accumulatorType   = cms.string("HGCDigiProducer"
                                                     feCfg   = cms.PSet( # 0 only ADC, 1 ADC with pulse shape, 2 ADC+TDC with pulse shape
                                                                         fwVersion         = cms.uint32(2),
                                                                         # leakage to bunches -2, -1, in-time, +1, +2, +3 (from J. Kaplon)
-                                                                        adcPulse          = cms.vdouble(0.00,0.017,0.817,0.163,0.003,0.000), 
+                                                                        adcPulse          = cms.vdouble(0.00, 0.017,   0.817,   0.163,  0.003,  0.000), 
+                                                                        pulseAvgT         = cms.vdouble(0.00, 23.42298,13.16733,6.41062,5.03946,4.5320), 
                                                                         # n bits for the ADC 
                                                                         adcNbits          = cms.uint32(10),
                                                                         # ADC saturation


### PR DESCRIPTION
1) adding average pulse shape time in each bx bin, according to Kaplon's simulation : this removes the previous average with respect to original toa from the bunch being leaked to the signal bunch -> this would bias in a strange way in the presence of pileup

2) Fixing bug in local variable in the CTOR for the FEElectronics, which sets the TDC saturation limit
